### PR TITLE
Fix cart update route and order status handling

### DIFF
--- a/Backend/constants/orderStatus.js
+++ b/Backend/constants/orderStatus.js
@@ -1,0 +1,10 @@
+const ORDER_STATUS = {
+    PENDING: 'pending',
+    PAID: 'paid',
+    PROCESSING: 'processing',
+    SHIPPED: 'shipped',
+    DELIVERED: 'delivered',
+    CANCELED: 'canceled'
+};
+
+module.exports = ORDER_STATUS;

--- a/Backend/controllers/PanierController.js
+++ b/Backend/controllers/PanierController.js
@@ -96,13 +96,15 @@ exports.getCartItems = async (req, res) => {
 
 exports.updateCartItem = async (req, res) => {
     try {
-        const { userid, productid, quantity } = req.body;
+        const { userid, quantity, productid } = req.body;
+        const { id } = req.params;
 
-        const cartItem = await Cart.findOne({ where: { userid, productid: padProductId(productid) } });
+        const prodId = removeLeftZeros(id || productid);
+
+        const cartItem = await Cart.findOne({ where: { userid, productid: prodId } });
         if (!cartItem) {
             return res.status(404).json({ message: 'Cart item not found' });
         }
-
         const product = await ProductService.getProductById(padProductId(cartItem.productid));
         const quantityNumber = parseInt(quantity, 10);
         if (isNaN(quantityNumber)) {

--- a/Backend/models/postgres_models/Commande.js
+++ b/Backend/models/postgres_models/Commande.js
@@ -1,6 +1,7 @@
 const { DataTypes } = require('sequelize');
 const sequelize = require('../../config/postgres');
 const Clients = require('../postgres_models/UserPg');
+const ORDER_STATUS = require('../../constants/orderStatus');
 
 const Order = sequelize.define('Order', {
     id: {
@@ -14,8 +15,9 @@ const Order = sequelize.define('Order', {
         defaultValue: DataTypes.NOW,
     },
     statusOrder: {
-        type: DataTypes.STRING,
+        type: DataTypes.ENUM(...Object.values(ORDER_STATUS)),
         allowNull: false,
+        defaultValue: ORDER_STATUS.PENDING,
     },
     totalAmount: {
         type: DataTypes.FLOAT,

--- a/Backend/services/CommandeServices.js
+++ b/Backend/services/CommandeServices.js
@@ -3,6 +3,7 @@ const OrderDetails = require('../models/postgres_models/DetailsCommande');
 const User = require('../models/postgres_models/UserPg');
 const Product = require('../models/mongo_models/Product');
 const sequelize = require('../config/postgres');
+const ORDER_STATUS = require('../constants/orderStatus');
 
 const padProductId = (id) => id.toString().padStart(24, '0');
 const removeLeftZeros = (str) => str.toString().replace(/^0+/, '');
@@ -10,9 +11,13 @@ const removeLeftZeros = (str) => str.toString().replace(/^0+/, '');
 class OrderService {
     static async createOrder(userId, statusOrder, totalAmount, products) {
         return sequelize.transaction(async (transaction) => {
+            const validStatus = Object.values(ORDER_STATUS).includes(statusOrder)
+                ? statusOrder
+                : ORDER_STATUS.PENDING;
+
             const order = await Order.create({
                 userId,
-                statusOrder,
+                statusOrder: validStatus,
                 totalAmount,
             }, { transaction });
 
@@ -66,6 +71,10 @@ class OrderService {
     static async updateOrder(orderId, updates) {
         const order = await Order.findByPk(orderId);
         if (!order) throw new Error('Commande non trouvée');
+
+        if (updates.statusOrder && !Object.values(ORDER_STATUS).includes(updates.statusOrder)) {
+            throw new Error('Statut de commande invalide');
+        }
 
         Object.assign(order, updates);
         await order.save();

--- a/FrontEnd/src/stores/Commande.ts
+++ b/FrontEnd/src/stores/Commande.ts
@@ -2,11 +2,12 @@ import { defineStore } from 'pinia';
 import axiosInstance from "@/services/api";
 import { ref } from 'vue';
 import { useAuthStore } from "@/stores/user";
+import { OrderStatus } from '@/types/orderStatus';
 
 export interface Order {
     id: number;
     dateOrder: Date;
-    statusOrder: string;
+    statusOrder: OrderStatus;
     totalAmount: number;
     userId: number;
     OrderDetails: OrderDetail[];
@@ -24,13 +25,13 @@ export interface OrderDetail {
 
 interface OrderCreateData {
     userId: number;
-    statusOrder: string;
+    statusOrder: OrderStatus;
     totalAmount: number;
     products: { productId: string; quantity: number }[];
 }
 
 interface OrderUpdateData {
-    statusOrder?: string;
+    statusOrder?: OrderStatus;
     totalAmount?: number;
     products?: { productId: string; quantity: number }[];
 }

--- a/FrontEnd/src/stores/panier.ts
+++ b/FrontEnd/src/stores/panier.ts
@@ -58,7 +58,7 @@ export const useCartStore = defineStore('cart', () => {
 
         if (isAuthenticated.value) {
             try {
-                await axiosInstance.put(`/cart/update`, {
+                await axiosInstance.put(`/cart/${product._id}`, {
                     userid: authStore.user?.id,
                     productid: product._id,
                     quantity

--- a/FrontEnd/src/types/orderStatus.ts
+++ b/FrontEnd/src/types/orderStatus.ts
@@ -1,0 +1,8 @@
+export enum OrderStatus {
+  Pending = 'pending',
+  Paid = 'paid',
+  Processing = 'processing',
+  Shipped = 'shipped',
+  Delivered = 'delivered',
+  Canceled = 'canceled'
+}


### PR DESCRIPTION
## Summary
- add order status constants
- enforce allowed order statuses server-side
- update cart controller to accept product ID in URL
- sync frontend with backend route for cart updates
- type order status on frontend

## Testing
- `npm run lint --prefix FrontEnd` *(fails: Unknown env config / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685163c1bad0832e95b9267a511da47a