### PR TITLE
Add order invoice print and payment confirmation

### DIFF
--- a/FrontEnd/src/components/profil/Commandes.vue
+++ b/FrontEnd/src/components/profil/Commandes.vue
@@ -40,6 +40,7 @@
             </tr>
             </tbody>
           </table>
+          <button class="print-btn" @click="generateInvoice">Print Invoice</button>
         </div>
       </div>
     </Modal>
@@ -51,6 +52,7 @@ import { ref, watch, computed } from 'vue';
 import { useOrderStore } from '@/stores/Commande';
 import { useAuthStore } from "@/stores/user";
 import Modal from '@/components/common/Modale.vue';
+import { printInvoice } from '@/utils/invoice';
 
 interface Order {
   id: number;
@@ -125,6 +127,12 @@ const viewOrderDetails = async (orderId: number) => {
     error.value = `Échec de la récupération des détails de la commande ${orderId}`;
   } finally {
     isLoading.value = false;
+  }
+};
+
+const generateInvoice = () => {
+  if (selectedOrder.value) {
+    printInvoice(selectedOrder.value as any);
   }
 };
 
@@ -307,5 +315,19 @@ watch(() => authStore.user, (newUser) => {
 
 .product-table tr:hover {
   background-color: #ddd;
+}
+
+.print-btn {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background-color: #28a745;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.print-btn:hover {
+  background-color: #218838;
 }
 </style>

--- a/FrontEnd/src/pages/Cart.vue
+++ b/FrontEnd/src/pages/Cart.vue
@@ -149,6 +149,7 @@ const checkout = async () => {
     console.log(orderId);
     console.log(response);
 
+    localStorage.setItem('currentOrderId', orderId);
     cartStore.clearCart();
     router.push({ path: '/checkout', query: { orderId } });
   } catch (error) {

--- a/FrontEnd/src/pages/PaymentSuccess.vue
+++ b/FrontEnd/src/pages/PaymentSuccess.vue
@@ -1,10 +1,98 @@
 <template>
-    <div>
-      <h1>Payment Successful</h1>
-      <p>Your payment was successful! Thank you for your purchase.</p>
+  <div class="payment-success">
+    <h1>Payment Successful</h1>
+    <p>Your payment was successful! Thank you for your purchase.</p>
+
+    <div v-if="order" class="order-summary">
+      <h2>Order #{{ order.id }}</h2>
+      <p>Date: {{ new Date(order.dateOrder).toLocaleDateString() }}</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Product</th>
+            <th>Price</th>
+            <th>Qty</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in order.OrderDetails" :key="item.productName">
+            <td>{{ item.productName }}</td>
+            <td>{{ item.unitPrice }}</td>
+            <td>{{ item.quantity }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Total: {{ order.totalAmount }}</h3>
+      <button @click="generateInvoice">Print Invoice</button>
     </div>
-  </template>
-  
-  <script setup lang="ts">
-  </script>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { useOrderStore } from '@/stores/Commande';
+import { printInvoice } from '@/utils/invoice';
+
+const router = useRouter();
+const orderStore = useOrderStore();
+const order = ref(null);
+
+const generateInvoice = () => {
+  if (order.value) {
+    printInvoice(order.value);
+  }
+};
+
+onMounted(async () => {
+  const stored = localStorage.getItem('currentOrderId');
+  const routeId = router.currentRoute.value.query.orderId as string;
+  const id = stored || routeId;
+  if (id) {
+    const fetched = await orderStore.fetchOrderById(Number(id));
+    if (fetched) {
+      order.value = fetched;
+      await orderStore.updateOrder(fetched.id, { statusOrder: 'Paid' });
+      localStorage.removeItem('currentOrderId');
+    }
+  }
+});
+</script>
+
+<style scoped>
+.payment-success {
+  padding: 20px;
+  text-align: center;
+}
+
+.order-summary {
+  margin-top: 20px;
+  display: inline-block;
+  text-align: left;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 10px;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+
+th {
+  background: #f2f2f2;
+}
+
+button {
+  padding: 10px 20px;
+  background: #28a745;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+</style>
   

--- a/FrontEnd/src/utils/invoice.ts
+++ b/FrontEnd/src/utils/invoice.ts
@@ -1,0 +1,46 @@
+export interface InvoiceProduct {
+  productName: string;
+  unitPrice: number;
+  quantity: number;
+}
+
+export interface InvoiceOrder {
+  id: number;
+  dateOrder: string | Date;
+  totalAmount: number;
+  OrderDetails: InvoiceProduct[];
+}
+
+export function printInvoice(order: InvoiceOrder) {
+  const win = window.open('', '_blank');
+  if (!win) return;
+  const date = new Date(order.dateOrder).toLocaleDateString();
+  const rows = order.OrderDetails.map(p =>
+    `<tr><td>${p.productName}</td><td>${p.unitPrice}</td><td>${p.quantity}</td></tr>`
+  ).join('');
+  const html = `
+    <html>
+    <head>
+      <title>Invoice ${order.id}</title>
+      <style>
+        table { width: 100%; border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background: #f2f2f2; }
+      </style>
+    </head>
+    <body>
+      <h1>Invoice #${order.id}</h1>
+      <p>Date: ${date}</p>
+      <table>
+        <thead><tr><th>Product</th><th>Price</th><th>Qty</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+      <h3>Total: ${order.totalAmount}</h3>
+    </body>
+    </html>
+  `;
+  win.document.write(html);
+  win.document.close();
+  win.focus();
+  win.print();
+}


### PR DESCRIPTION
## Summary
- store orderId when creating an order
- show order details on payment success and allow invoice printing
- add invoice print option in user order history
- utility helper for invoice print

## Testing
- `npm run lint` *(fails: invalid option)*
- `npm run build` *(fails: run-p: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685169d5e55c832e8b224731588ac658