### PR TITLE
Implement stock alerts and new roles

### DIFF
--- a/Backend/controllers/AlertController.js
+++ b/Backend/controllers/AlertController.js
@@ -1,0 +1,54 @@
+const Alert = require('../models/postgres_models/Alert');
+const StockAlert = require('../models/postgres_models/StockAlert');
+
+async function createAlert(req, res) {
+  try {
+    const alert = await Alert.create({
+      alert_type: req.body.alert_type,
+      status: 'active',
+      user_id: req.user.userId,
+      product_id: req.body.product_id
+    });
+    res.status(201).json(alert);
+  } catch (err) {
+    console.error('createAlert', err);
+    res.status(500).json({ message: 'Erreur interne du serveur' });
+  }
+}
+
+async function getAlerts(req, res) {
+  try {
+    const alerts = await Alert.findAll({ where: { user_id: req.user.userId } });
+    res.status(200).json(alerts);
+  } catch (err) {
+    console.error('getAlerts', err);
+    res.status(500).json({ message: 'Erreur interne du serveur' });
+  }
+}
+
+async function deleteAlert(req, res) {
+  try {
+    const id = req.params.id;
+    await Alert.destroy({ where: { id, user_id: req.user.userId } });
+    res.status(204).send();
+  } catch (err) {
+    console.error('deleteAlert', err);
+    res.status(500).json({ message: 'Erreur interne du serveur' });
+  }
+}
+
+async function createStockAlert(req, res) {
+  try {
+    const alert = await StockAlert.create({
+      productId: req.body.productId,
+      threshold: req.body.threshold,
+      userId: req.user.userId
+    });
+    res.status(201).json(alert);
+  } catch (err) {
+    console.error('createStockAlert', err);
+    res.status(500).json({ message: 'Erreur interne du serveur' });
+  }
+}
+
+module.exports = { createAlert, getAlerts, deleteAlert, createStockAlert };

--- a/Backend/controllers/AuthController.js
+++ b/Backend/controllers/AuthController.js
@@ -8,6 +8,10 @@ require('dotenv').config();
 const JWT_SECRET = process.env.JWT_SECRET;
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET;
 
+function isPasswordStrong(password) {
+    return /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{12,}$/.test(password);
+}
+
 function generateToken(user) {
     if (!user.role) {
         throw new Error('User role is not defined');
@@ -52,6 +56,10 @@ async function register(req, res, next) {
 
     if (password !== password_confirm) {
         return res.status(422).json({ message: 'Les mots de passe ne correspondent pas' });
+    }
+
+    if (!isPasswordStrong(password)) {
+        return res.status(422).json({ message: 'Le mot de passe doit comporter au moins 12 caracteres, avec chiffres, lettres majuscules et minuscules et symboles.' });
     }
 
     try {
@@ -233,6 +241,10 @@ async function resetPassword(req, res) {
         return res.status(422).json({ message: 'Les mots de passe ne correspondent pas' });
     }
 
+    if (!isPasswordStrong(newPassword)) {
+        return res.status(422).json({ message: 'Le mot de passe doit comporter au moins 12 caracteres, avec chiffres, lettres majuscules et minuscules et symboles.' });
+    }
+
     try {
         const result = await User.updateUserByToken(token, {
             password: await bcrypt.hash(newPassword, 10),
@@ -310,4 +322,21 @@ async function updateUser(req, res) {
     }
 }
 
-module.exports = { user, register, login, logout, users, confirmEmail, resetPassword, requestPasswordReset, refreshToken, updateUser };
+async function impersonateUser(req, res) {
+    const { id } = req.params;
+
+    try {
+        const user = await User.findByPk(id);
+        if (!user) {
+            return res.status(404).json({ message: 'Utilisateur non trouvé' });
+        }
+        const accessToken = generateToken(user);
+        const refreshToken = generateRefreshToken(user);
+        res.status(200).json({ accessToken, refreshToken, user });
+    } catch (error) {
+        console.error('Erreur impersonate user:', error);
+        res.status(500).json({ message: 'Erreur interne du serveur' });
+    }
+}
+
+module.exports = { user, register, login, logout, users, confirmEmail, resetPassword, requestPasswordReset, refreshToken, updateUser, impersonateUser };

--- a/Backend/middleware/authAdmin.js
+++ b/Backend/middleware/authAdmin.js
@@ -40,6 +40,31 @@ function authenticateAdmin(req, res, next) {
     }
 }
 
+function authenticateCompta(req, res, next) {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+        return res.status(401).json({ message: 'Non autorisé' });
+    }
+
+    const token = authHeader.split(' ')[1];
+    if (!token) {
+        return res.status(401).json({ message: 'Non autorisé' });
+    }
+
+    try {
+        const decoded = jwt.verify(token, JWT_SECRET);
+        if (decoded.role !== 'ROLE_COMPTA' && decoded.role !== 'admin') {
+            return res.status(403).json({ message: 'Accès refusé.' });
+        }
+        req.userId = decoded.userId;
+        req.userRole = decoded.role;
+        req.user = decoded;
+        next();
+    } catch (error) {
+        return res.status(401).json({ message: 'Token invalide' });
+    }
+}
+
 function authenticateToken(req, res, next) {
     const authHeader = req.header('Authorization');
     const token = authHeader ? authHeader.split(' ')[1] : req.cookies.token;
@@ -52,4 +77,4 @@ function authenticateToken(req, res, next) {
     });
 }
 
-module.exports = { authenticateAdmin, authenticateToken };
+module.exports = { authenticateAdmin, authenticateToken, authenticateCompta };

--- a/Backend/models/postgres_models/StockAlert.js
+++ b/Backend/models/postgres_models/StockAlert.js
@@ -1,0 +1,25 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../../config/postgres');
+const Product = require('./ProductPg');
+const User = require('./UserPg');
+
+const StockAlert = sequelize.define('StockAlert', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true
+  },
+  threshold: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+    defaultValue: 0
+  }
+}, {
+  tableName: 'StockAlert',
+  timestamps: false
+});
+
+StockAlert.belongsTo(Product, { foreignKey: 'productId' });
+StockAlert.belongsTo(User, { foreignKey: 'userId' });
+
+module.exports = StockAlert;

--- a/Backend/models/postgres_models/StockHistory.js
+++ b/Backend/models/postgres_models/StockHistory.js
@@ -1,0 +1,30 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../../config/postgres');
+const Product = require('./ProductPg');
+
+const StockHistory = sequelize.define('StockHistory', {
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true
+  },
+  productId: {
+    type: DataTypes.INTEGER,
+    references: { model: Product, key: 'id' }
+  },
+  quantity: {
+    type: DataTypes.INTEGER,
+    allowNull: false
+  },
+  createdAt: {
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW
+  }
+}, {
+  tableName: 'StockHistory',
+  timestamps: false
+});
+
+StockHistory.belongsTo(Product, { foreignKey: 'productId' });
+
+module.exports = StockHistory;

--- a/Backend/routes/api/alertRoutes.js
+++ b/Backend/routes/api/alertRoutes.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const { authenticateToken } = require('../../middleware/authAdmin');
+const AlertController = require('../../controllers/AlertController');
+
+router.post('/', authenticateToken, AlertController.createAlert);
+router.get('/', authenticateToken, AlertController.getAlerts);
+router.delete('/:id', authenticateToken, AlertController.deleteAlert);
+router.post('/stock', authenticateToken, AlertController.createStockAlert);
+
+module.exports = router;

--- a/Backend/routes/api/auth.js
+++ b/Backend/routes/api/auth.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const authControllers = require('../../controllers/AuthController');
-const { authenticateToken, authenticateAdmin } = require('../../middleware/authAdmin');
+const { authenticateToken, authenticateAdmin, authenticateCompta } = require('../../middleware/authAdmin');
 
 // Routes publiques d'authentification
 router.post('/register', authControllers.register);
@@ -20,5 +20,6 @@ router.get('/me',authenticateToken, authControllers.user);
 router.get('/users',authenticateToken, authControllers.users);
 
 router.patch('/user/:id', authenticateToken, authControllers.updateUser);
+router.post('/impersonate/:id', authenticateCompta, authControllers.impersonateUser);
 
 module.exports = router;

--- a/Backend/server.js
+++ b/Backend/server.js
@@ -24,6 +24,7 @@ const PaymentRoutes = require('./routes/api/PaymentRoutes');
 const ReturnRoutes = require('./routes/api/ReturnsRoutes');
 const stripeRoutes = require('./routes/api/stripeRoutes');
 const analyticsRoutes = require('./routes/api/analyticsRoutes');
+const alertRoutes = require('./routes/api/alertRoutes');
 
 
 const cron = require('node-cron');
@@ -62,6 +63,7 @@ app.use('/api/payments', PaymentRoutes);
 app.use('/api/returns', ReturnRoutes);
 app.use('/api/stripe', stripeRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/alerts', alertRoutes);
 
 
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));

--- a/Backend/services/productService.js
+++ b/Backend/services/productService.js
@@ -1,6 +1,7 @@
 const ProductSQL = require('../models/postgres_models/ProductPg');
 const ProductMongo = require('../models/mongo_models/Product');
 const denormalizeProduct = require('../services/denormalizeProduct');
+const { recordStock } = require('./stockService');
 
 class ProductService {
     static async getProducts() {
@@ -89,6 +90,8 @@ class ProductService {
                 { stock_available: newStock },
                 { new: true }
             );
+
+            await recordStock(productId, newStock);
 
             return { updatedSQLProduct };
         } catch (error) {

--- a/Backend/services/stockService.js
+++ b/Backend/services/stockService.js
@@ -1,0 +1,23 @@
+const { Op } = require('sequelize');
+const StockHistory = require('../models/postgres_models/StockHistory');
+const StockAlert = require('../models/postgres_models/StockAlert');
+const User = require('../models/postgres_models/UserPg');
+const { sendEmail } = require('./mailer');
+
+async function recordStock(productId, quantity) {
+  await StockHistory.create({ productId, quantity });
+
+  const alerts = await StockAlert.findAll({
+    where: {
+      productId,
+      threshold: { [Op.gte]: quantity }
+    },
+    include: [User]
+  });
+
+  for (const alert of alerts) {
+    await sendEmail(alert.User.email, 'Alerte de stock', `Le stock du produit ${productId} est à ${quantity}.`);
+  }
+}
+
+module.exports = { recordStock };


### PR DESCRIPTION
## Summary
- add models for stock alerts and history
- enforce password complexity
- enable impersonation for ROLE_COMPTA
- add stock alert recording and mailing
- expose alert routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint missing option)*

------
https://chatgpt.com/codex/tasks/task_e_68516a9e6e4c832eb38075af2af0b72b