### PR TITLE
Fix front-end/back-end mismatches

### DIFF
--- a/FrontEnd/src/stores/Addresses.ts
+++ b/FrontEnd/src/stores/Addresses.ts
@@ -74,7 +74,7 @@ export const useAddressStore = defineStore('address', () => {
             if (authStore.isAuthenticated) {
                 const response = await axiosInstance.post('/addresses', {
                     ...addressData,
-                    userid: authStore.user?.id
+                    userId: authStore.user?.id
                 });
                 addresses.value.push(response.data);
             } else {

--- a/FrontEnd/src/stores/payment.ts
+++ b/FrontEnd/src/stores/payment.ts
@@ -79,7 +79,7 @@ const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
            try {
                const items = cartItems.value;
    
-               const response = await axiosInstance.post('/stripe/create-paypal-checkout-session', {
+               const response = await axiosInstance.post('/stripe/create-checkout-session-paypal', {
                    items,
                    customer: { email: customerEmail || 'test@example.com' }
                });

--- a/FrontEnd/src/stores/products.ts
+++ b/FrontEnd/src/stores/products.ts
@@ -63,8 +63,8 @@ export const useProductStore = defineStore('product', () => {
                     'Authorization': `Bearer ${authStore.token}`
                 }
             });
-            products.value.push(response.data);
-            console.log('Product created:', response.data);
+            products.value.push(response.data.product);
+            console.log('Product created:', response.data.product);
         } catch (error) {
             console.error('Error creating product:', error);
             throw new Error('Failed to create product');
@@ -73,7 +73,7 @@ export const useProductStore = defineStore('product', () => {
 
     const uploadProductImages = async (formData: FormData): Promise<void> => {
         try {
-            await axiosInstance.post('/upload', formData, {
+            await axiosInstance.post('/upload/upload', formData, {
                 headers: {
                     'Content-Type': 'multipart/form-data',
                     'Authorization': `Bearer ${authStore.token}`
@@ -96,9 +96,9 @@ export const useProductStore = defineStore('product', () => {
             });
             const index = products.value.findIndex(p => p._id === id);
             if (index !== -1) {
-                products.value[index] = response.data;
+                products.value[index] = response.data.product;
             }
-            console.log('Product updated:', response.data);
+            console.log('Product updated:', response.data.product);
         } catch (error) {
             console.error('Error updating product:', error);
             throw new Error('Failed to update product');
@@ -129,9 +129,9 @@ export const useProductStore = defineStore('product', () => {
             });
             const index = products.value.findIndex(p => p._id === id);
             if (index !== -1) {
-                products.value[index] = { ...products.value[index], ...response.data };
+                products.value[index] = { ...products.value[index], ...response.data.product };
             }
-            console.log('Product stock updated:', response.data);
+            console.log('Product stock updated:', response.data.product);
         } catch (error) {
             console.error('Error updating product stock:', error);
             throw new Error('Failed to update product stock');

--- a/FrontEnd/src/stores/user.ts
+++ b/FrontEnd/src/stores/user.ts
@@ -27,6 +27,16 @@ export const useAuthStore = defineStore('auth', () => {
 
     const isAuthenticated = computed(() => !!user.value);
 
+    function mapUserResponse(u: any): User {
+        return {
+            id: u.id,
+            email: u.email,
+            firstName: u.firstName ?? u.firstname,
+            lastName: u.lastName ?? u.lastname,
+            role: u.role
+        };
+    }
+
     const persistState = () => {
         localStorage.setItem('auth', JSON.stringify({
             user: user.value,
@@ -78,7 +88,7 @@ export const useAuthStore = defineStore('auth', () => {
             if (response.data.message.includes('Veuillez confirmer votre email')) {
                 throw new Error(response.data.message);
             }
-            user.value = response.data.user;
+            user.value = mapUserResponse(response.data.user);
             token.value = response.data.accessToken;
             refreshToken.value = response.data.refreshToken;
             if (token.value) {
@@ -165,7 +175,7 @@ export const useAuthStore = defineStore('auth', () => {
     async function fetchUser() {
         try {
             const response = await axiosInstance.get('auth/me');
-            user.value = response.data;
+            user.value = mapUserResponse(response.data.user);
         } catch (error) {
             throw error;
         }
@@ -192,7 +202,7 @@ export const useAuthStore = defineStore('auth', () => {
     async function updateProfile(profileData) {
         try {
             const response = await axiosInstance.patch(`/auth/user/${user.value?.id}`, profileData);
-            user.value = response.data.user;
+            user.value = mapUserResponse(response.data.user);
         } catch (error) {
             console.error('Error updating profile:', error);
         }


### PR DESCRIPTION
## Summary
- normalize user info returned from API
- fix user fetch and profile update
- correct address creation payload
- align product store with controller responses
- update upload and Stripe PayPal endpoints

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_685185255368832ebecc422510f6e332