### PR TITLE
Fix user name conventions

### DIFF
--- a/FrontEnd/src/components/admin/UserManagement.vue
+++ b/FrontEnd/src/components/admin/UserManagement.vue
@@ -59,8 +59,8 @@ const selectedUser = ref<Partial<User> | null>(null);
 
 const users = ref<User[]>([]);
 const columns: Column<User>[] = [
-  { key: 'firstname', label: 'First Name', searchable: true },
-  { key: 'lastname', label: 'Last Name', searchable: true },
+  { key: 'firstName', label: 'First Name', searchable: true },
+  { key: 'lastName', label: 'Last Name', searchable: true },
   { key: 'email', label: 'Email', searchable: true },
   { key: 'role', label: 'Role' }
 ];

--- a/FrontEnd/src/stores/user.ts
+++ b/FrontEnd/src/stores/user.ts
@@ -184,7 +184,7 @@ export const useAuthStore = defineStore('auth', () => {
     async function fetchUsers() {
         try {
             const response = await axiosInstance.get('auth/users');
-            return response.data.users;
+            return response.data.users.map((u: any) => mapUserResponse(u));
         } catch (error) {
             throw error;
         }


### PR DESCRIPTION
## Summary
- update `fetchUsers` to normalize name properties
- use `firstName`/`lastName` in user management table

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518e093940832e8c99d68f04cfc5fb