### PR TITLE
Fix frontend build errors

### DIFF
--- a/FrontEnd/src/components/widgets/BarChart.vue
+++ b/FrontEnd/src/components/widgets/BarChart.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import type { ChartItem } from 'chart.js'
 import { ref, onMounted } from 'vue';
 import { Chart, BarController, BarElement, CategoryScale, LinearScale, Title } from 'chart.js';
 
@@ -18,7 +19,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 
 onMounted(() => {
   if (canvas.value) {
-    new Chart(canvas.value, {
+    new Chart(canvas.value as ChartItem, {
       type: 'bar',
       data: props.chartData
     });

--- a/FrontEnd/src/components/widgets/LineChart.vue
+++ b/FrontEnd/src/components/widgets/LineChart.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import type { ChartItem } from 'chart.js'
 import { ref, onMounted } from 'vue';
 import { Chart, LineController, LineElement, PointElement, LinearScale, CategoryScale, Title } from 'chart.js';
 
@@ -18,7 +19,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 
 onMounted(() => {
   if (canvas.value) {
-    new Chart(canvas.value, {
+    new Chart(canvas.value as ChartItem, {
       type: 'line',
       data: props.chartData
     });

--- a/FrontEnd/src/components/widgets/PieChart.vue
+++ b/FrontEnd/src/components/widgets/PieChart.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import type { ChartItem } from 'chart.js'
 import { ref, onMounted } from 'vue';
 import { Chart, PieController, ArcElement, CategoryScale, Title } from 'chart.js';
 
@@ -18,7 +19,7 @@ const canvas = ref<HTMLCanvasElement | null>(null);
 
 onMounted(() => {
   if (canvas.value) {
-    new Chart(canvas.value, {
+    new Chart(canvas.value as ChartItem, {
       type: 'pie',
       data: props.chartData
     });

--- a/FrontEnd/src/pages/Payment.vue
+++ b/FrontEnd/src/pages/Payment.vue
@@ -45,7 +45,6 @@
               <div v-for="item in cartItems" :key="item._id" class="cart-item">
                   <div class="item-details">
                       <h4>{{ item.name }}</h4>
-                      <p>Size: {{ item.size }}</p>
                       <p>Quantity: {{ item.quantity }}</p>
                       <p>${{ item.price }}</p>
                       <button @click="removeItem(item._id)">Remove</button>

--- a/FrontEnd/src/pages/PaymentSuccess.vue
+++ b/FrontEnd/src/pages/PaymentSuccess.vue
@@ -33,6 +33,7 @@ import { ref, onMounted } from 'vue';
 import { useRouter } from 'vue-router';
 import { useOrderStore } from '@/stores/Commande';
 import { printInvoice } from '@/utils/invoice';
+import { OrderStatus } from '@/types/orderStatus'
 
 const router = useRouter();
 const orderStore = useOrderStore();
@@ -52,7 +53,7 @@ onMounted(async () => {
     const fetched = await orderStore.fetchOrderById(Number(id));
     if (fetched) {
       order.value = fetched;
-      await orderStore.updateOrder(fetched.id, { statusOrder: 'Paid' });
+      await orderStore.updateOrder(fetched.id, { statusOrder: OrderStatus.Paid });
       localStorage.removeItem('currentOrderId');
     }
   }

--- a/FrontEnd/src/router/router.ts
+++ b/FrontEnd/src/router/router.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import type { RouteLocationNormalized } from 'vue-router'
 import { useAuthStore } from '@/stores/user'
 
 import Register from '../pages/Register.vue'
@@ -86,7 +87,7 @@ const routes = [
     name: 'ProductDetails',
     component: ProductDetails,
     meta: { requiresAuth: false },
-    props: (route) => ({ id: decodeBase64(route.params.id as string) })
+    props: (route: RouteLocationNormalized) => ({ id: decodeBase64(route.params.id as string) })
   },
   {
     path: '/cart',

--- a/FrontEnd/src/stores/payment.ts
+++ b/FrontEnd/src/stores/payment.ts
@@ -3,6 +3,7 @@
    // stores/payment.ts
 import { ref } from 'vue';
 import { defineStore } from 'pinia';
+import type { Stripe, StripeElements, StripeCardElement } from '@stripe/stripe-js'
 import axiosInstance from "@/services/api";
 import { loadStripe } from '@stripe/stripe-js';
 import { useCartStore } from '@/stores/panier';
@@ -12,9 +13,9 @@ const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
    export const usePaymentStore = defineStore('payment', () => {
        const loading = ref(false);
        const error = ref('');
-      const stripe = ref(null);
-      const elements = ref(null);
-      const card = ref(null);
+      const stripe = ref<Stripe | null>(null);
+      const elements = ref<StripeElements | null>(null);
+      const card = ref<StripeCardElement | null>(null);
 
       const cartStore = useCartStore();
 
@@ -22,9 +23,9 @@ const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
        
        const initializeStripe = async () => {
            stripe.value = await stripePromise;
-           elements.value = stripe.value.elements();
-           card.value = elements.value.create('card');
-           card.value.mount('#card-element');
+           elements.value = stripe.value!.elements();
+            card.value = elements.value!.create('card');
+           card.value!.mount('#card-element');
        };
    
        const createPaymentIntent = async (amount: number, customerEmail: string) => {

--- a/FrontEnd/src/stores/user.ts
+++ b/FrontEnd/src/stores/user.ts
@@ -199,7 +199,7 @@ export const useAuthStore = defineStore('auth', () => {
         }
     }
 
-    async function updateProfile(profileData) {
+    async function updateProfile(profileData: any) {
         try {
             const response = await axiosInstance.patch(`/auth/user/${user.value?.id}`, profileData);
             user.value = mapUserResponse(response.data.user);
@@ -208,7 +208,7 @@ export const useAuthStore = defineStore('auth', () => {
         }
     }
 
-    async function updatePassword(currentPassword, newPassword) {
+    async function updatePassword(currentPassword: string, newPassword: string) {
         try {
             const response = await axiosInstance.patch(`/auth/user/${user.value?.id}`, { password: newPassword });
             return response.data;


### PR DESCRIPTION
## Summary
- import `RouteLocationNormalized` for typed route props
- type parameters in `user` store
- strongly type Stripe objects and add null assertions in `payment` store
- cast chart canvas refs to `ChartItem` in widgets
- remove unused size display in payment page
- update payment success page to use enum `OrderStatus`

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run type-check` *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851bebff010832ea5a49d29c5014337