### PR TITLE
Improve front-end env config

### DIFF
--- a/FrontEnd/index.html
+++ b/FrontEnd/index.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8">
-    <link rel="icon" href="/favicon.ico">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Vite App</title>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>MambaFit Marketplace</title>
   </head>
-  <body>
+  <body class="font-sans bg-gray-50 text-gray-900">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/FrontEnd/postcss.config.js
+++ b/FrontEnd/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/FrontEnd/src/assets/main.css
+++ b/FrontEnd/src/assets/main.css
@@ -1,4 +1,8 @@
-@import 'base.css';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@import './base.css';
 /* 
 #app {
   max-width: 1280px;

--- a/FrontEnd/src/components/UI/BestSellers_Products.vue
+++ b/FrontEnd/src/components/UI/BestSellers_Products.vue
@@ -82,10 +82,11 @@ const filterByCategory = (category: string) => {
   filteredProducts.value = products.value.filter(product => product.category === category);
 };
 
+import { backendUrl } from '@/utils/backend';
+
 const getImage = (product: Product) => {
   if (product.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    const imageUrl = `${baseUrl}/${product.images[0]}`;
+    const imageUrl = `${backendUrl}/${product.images[0]}`;
     console.log('Image URL:', imageUrl);
     return imageUrl;
   }

--- a/FrontEnd/src/components/UI/FicheProducts.vue
+++ b/FrontEnd/src/components/UI/FicheProducts.vue
@@ -50,6 +50,7 @@ import { useCartStore } from '@/stores/panier';
 import defaultImage from '@/assets/ui_assets/image1.png';
 import type { Product } from "@/stores/products";
 import { encodeBase64 } from '@/utils/encodage';
+import { backendUrl } from '@/utils/backend';
 
 
 const props = defineProps<{
@@ -59,8 +60,7 @@ const props = defineProps<{
 
 const getImage = (product: Product) => {
   if (product.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    return `${baseUrl}/${product.images[0]}`;
+    return `${backendUrl}/${product.images[0]}`;
   }
   return defaultImage;
 };

--- a/FrontEnd/src/components/admin/ProductManagement.vue
+++ b/FrontEnd/src/components/admin/ProductManagement.vue
@@ -84,10 +84,11 @@ watch(() => productStore.products, (newProducts) => {
   console.log('Products in store changed:', newProducts);
 }, { deep: true });
 
+import { backendUrl } from '@/utils/backend';
+
 const getImage = (product: Partial<Product> | undefined) => {
   if (product?.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    return `${baseUrl}/${product.images[0]}`;
+    return `${backendUrl}/${product.images[0]}`;
   }
   return 'path/to/default/image.jpg';
 };

--- a/FrontEnd/src/pages/Cart.vue
+++ b/FrontEnd/src/pages/Cart.vue
@@ -116,10 +116,11 @@ const orderInformation = ref([
   { title: 'Shipping Options', description: 'Various shipping options are available for your convenience.' }
 ]);
 
+import { backendUrl } from '@/utils/backend';
+
 const getImage = (product) => {
   if (product.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    return `${baseUrl}/${product.images[0]}`;
+    return `${backendUrl}/${product.images[0]}`;
   }
   return defaultImage;
 };

--- a/FrontEnd/src/pages/Checkout.vue
+++ b/FrontEnd/src/pages/Checkout.vue
@@ -59,10 +59,11 @@ const closeErrorModal = () => {
   showErrorModal.value = false;
 };
 
+import { backendUrl } from '@/utils/backend';
+
 const getImage = (product) => {
   if (product.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    return `${baseUrl}/${product.images[0]}`;
+    return `${backendUrl}/${product.images[0]}`;
   }
   return defaultImage;
 };

--- a/FrontEnd/src/pages/ProductDetails.vue
+++ b/FrontEnd/src/pages/ProductDetails.vue
@@ -77,10 +77,11 @@ const addToCart = (product: Product) => {
   cartStore.addToCart(product, quantity.value);
 };
 
+import { backendUrl } from '@/utils/backend';
+
 const getImage = (product: { images: string[] }) => {
   if (product.images && product.images.length > 0) {
-    const baseUrl = 'http://localhost:3000';
-    return `${baseUrl}/${product.images[0]}`;
+    return `${backendUrl}/${product.images[0]}`;
   }
   return defaultImage;
 };

--- a/FrontEnd/src/services/api.ts
+++ b/FrontEnd/src/services/api.ts
@@ -1,8 +1,9 @@
 // services/api.ts
 import axios from 'axios';
+import { apiUrl } from '@/utils/backend';
 
 const axiosInstance = axios.create({
-    baseURL: 'http://localhost:3000/api',
+    baseURL: apiUrl,
     headers: {
         'Content-Type': 'application/json',
     },

--- a/FrontEnd/src/stores/payment.ts
+++ b/FrontEnd/src/stores/payment.ts
@@ -4,6 +4,7 @@ import type { Stripe, StripeElements, StripeCardElement } from '@stripe/stripe-j
 import axiosInstance from "@/services/api";
 import { loadStripe } from '@stripe/stripe-js';
 import { useCartStore } from '@/stores/panier';
+import router from '@/router/router';
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
    
@@ -62,7 +63,7 @@ const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY || '');
                     error.value = stripeError.message ?? '';
                 } else {
                     console.log('Payment successful!', paymentIntent);
-                    window.location.href = 'http://localhost:5173/paymentSuccess'; // Redirect to success page
+                    router.push('/paymentSuccess');
                 }
             } catch (err) {
                 console.error('Error during card payment:', err);

--- a/FrontEnd/src/utils/backend.ts
+++ b/FrontEnd/src/utils/backend.ts
@@ -1,0 +1,3 @@
+export const backendUrl = import.meta.env.VITE_APP_API_URL || 'http://localhost:3000';
+export const apiUrl = `${backendUrl}/api`;
+

--- a/FrontEnd/tailwind.config.js
+++ b/FrontEnd/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{vue,js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- hook API base URL to environment file
- centralize backend URL logic
- wire up TailwindCSS
- cleanup checkout/cart image URL helpers
- refine navigation after payment
- tweak HTML body defaults

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path' and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6851d516440c832ebc4df2def7c715cb